### PR TITLE
Fix tests, download Varnish 4.0.3, fix daemon location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
+sudo: false
 language: python
 python:
   - 2.7
+addons:
+  apt:
+    packages:
+    - python-docutils
+    - libpcre3
+    - libpcre3-dev
+    - pkg-config
 install:
   - mkdir -p buildout-cache/{eggs,downloads}
   - pip install zc.buildout

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Changelog
 2.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix daemon location of script part of the recipe (/usr/bin/varnishd was
+  always used. 
+  [fredvd]
 
+- Fix tests,  download Varnish 4.0.3 as download.
+  [fredvd]
 
 2.0a1 (2015-03-02)
 ------------------

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -8,7 +8,7 @@ import re
 import zc.buildout
 
 DEFAULT_DOWNLOAD_URLS = {
-    '4': 'https://repo.varnish-cache.org/source/varnish-4.0.2.tar.gz',
+    '4': 'https://repo.varnish-cache.org/source/varnish-4.0.3.tar.gz',
 }
 DEFAULT_VERSION = '4'
 

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -352,9 +352,9 @@ class ScriptRecipe(BaseRecipe):
             'daemon',
             self.get_from_section(
                 self.options['build-part'],
-                'daemon',
-                '/usr/sbin/varnishd'
-            )
+                'location',
+                '/usr'
+            ) + '/sbin/varnishd'
         )
 
         self.options.setdefault(

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -50,7 +50,7 @@ Check the contents of the control script are correct::
     >>> print open(varnish_bin).read()
     #!/bin/sh
     exec ...sample-buildout/parts/varnish-build/sbin/varnishd \
-        -f "...sample-buildout/parts/varnish/varnish.vcl" \
+        -f "...sample-buildout/parts/varnish-configuration/varnish.vcl" \
         -P "...sample-buildout/parts/varnish/varnish.pid" \
         -a 127.0.0.1:8000 \
         -s file,"...sample-buildout/parts/varnish/storage",256M \
@@ -60,7 +60,8 @@ Check the contents of the control script are correct::
 Check the config is syntactically correct by compiling it to C::
 
     >>> print system(varnish_bin + ' -C')
-    ...
+    /* ---===### include/vcl.h ###===--- */
+    <BLANKLINE>
     /*
      * NB:  This file is machine generated, DO NOT EDIT!
      *
@@ -84,8 +85,10 @@ Let's run it::
 
     >>> print system(buildout_bin)
     Uninstalling varnish.
-    Installing varnish.
     Updating varnish-build.
+    Updating varnish-configuration.
+    Installing varnish.
+    ...
 
 Check the contents of the control script are correct::
 
@@ -111,9 +114,11 @@ Let's run it::
 
     >>> print system(buildout_bin)
     Uninstalling varnish.
-    Installing varnish.
     Updating varnish-build.
-
+    Updating varnish-configuration.
+    Installing varnish.
+    ...
+    
 Check the contents of the control script reflect our new options::
 
     >>> 'varnish' in os.listdir('bin')
@@ -125,7 +130,7 @@ Check the contents of the control script reflect our new options::
         -s malloc,2.71G \
     ...
 
-Test the varnish download::
+Test the varnish download with an older version::
 
     >>> varnish_4 = simplest + '''
     ... varnish_version = 4
@@ -137,8 +142,7 @@ Let's run it::
 
     >>> print system(buildout_bin)
     Uninstalling varnish.
-    Installing varnish.
     Updating varnish-build.
-
-
-
+    Updating varnish-configuration.
+    Installing varnish.
+    ...

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -16,24 +16,26 @@ Let's create a minimum buildout that uses the current plone.recipe.varnish::
 
     >>> simplest = '''
     ... [buildout]
-    ... parts = varnish-build varnish
+    ... parts = varnish-build varnish-configuration varnish
     ... find-links = %(sample_buildout)s/eggs
     ...
     ... [varnish-build]
     ... recipe = plone.recipe.varnish:build
     ... jobs = 4
     ...
-    ... [varnish]
-    ... recipe = plone.recipe.varnish
+    ... [varnish-configuration]
+    ... recipe = plone.recipe.varnish:configuration
     ... daemon = ${varnish-build:location}/sbin/varnishd
-    ... backends = 127.0.0.1:8080
-    ... '''
+    ... backends = 127.0.0.1:8081
+    ...
+    ... [varnish]
+    ... recipe = plone.recipe.varnish:script'''
     >>> write('buildout.cfg', simplest % globals())
 
 Let's run it::
 
     >>> print system(buildout_bin)
-    Installing varnish.    Installing varnish-build.
+    Installing varnish-build.
     varnish-build: Downloading ...
     varnish-build: Unpacking and configuring
     ...

--- a/plone/recipe/varnish/tests/vclgen.rst
+++ b/plone/recipe/varnish/tests/vclgen.rst
@@ -86,6 +86,7 @@ Basic check::
     ...     ],
     ...     'gracehealthy': '10s',
     ...     'gracesick': '1h',
+    ...     'code404page' : True,
     ... }
     >>> vg = VclGenerator(config)
     >>> vg._vhostings([])


### PR DESCRIPTION
* Some tests were broken after the part split in script, buildout and configuration.
* When testing the recipe I found that /usr/bin/varnishd was always used as location in the start script generation.
* 4.0.3 is now current.