### PR TITLE
Made three possible values for the ``varnish_version`` option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     - libpcre3
     - libpcre3-dev
     - pkg-config
+    - graphviz
 before_install:
   - mkdir -p $HOME/buildout-cache/{eggs,downloads}
   - mkdir $HOME/.buildout
@@ -36,4 +37,3 @@ after_success:
   - bin/createcoverage
   - python -m coverage.pickle2json
   - coveralls
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,15 @@ Changelog
 2.0a5 (unreleased)
 ------------------
 
+- Made three possible values for the ``varnish_version`` option.  4.0
+  (uses 4.0.3), 4.1 (uses 4.1.3), 4 (uses 4.1.3).  4.0 is the default for now.
+  4 is intended to be updated to 4.2.x when this is released and found
+  to work.
+  [maurits]
+
 - Fix: to disable the secret-file authentication, an empty parameter should be
   passed to varnishd on startup.
-  [fredvd, nutjob4life]    
+  [fredvd, nutjob4life]
 
 
 2.0a4 (2016-02-23)
@@ -30,7 +36,7 @@ Changelog
 ------------------
 
 - Fix daemon location of script part of the recipe (/usr/bin/varnishd was
-  always used. 
+  always used.
   [fredvd]
 
 - Fix tests,  download Varnish 4.0.3 as download.
@@ -46,7 +52,7 @@ Changelog
   - use jinja2 templates for vcl
   - refactor vcl generation out in own testable class
   - change fixup cookies into a cookie whitelist
-  - split up recipe in 3 parts: build, configuration generation and script 
+  - split up recipe in 3 parts: build, configuration generation and script
     generation.
 
   [jensens]

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,14 @@ Two parameters are different/ extra:
     needed to your CPU resources.
 
 ``varnish_version``
-    Varnish target version. Default is ``4``.
+    Varnish target version. Default is ``4.0``.  Options are:
+
+    - 4.0: uses 4.0.3, will stick to 4.0.x
+    - 4.1: uses 4.1.3, will stick to 4.1.x
+    - 4: uses 4.1.3, will stick to 4.x
+
+    The exact version and the default version may be changed in future release of this recipe.
+    4.1 seems fine, but gives problems with the tests, so it is not the default yet.
 
 
 VCL Configuration Generator
@@ -388,16 +395,16 @@ Start varnish as a daemon or in foreground with the given settings. These option
     (like the varnishadm tool) to have a shared key to authenticate. By default
     if no secret-file is specified, it's no longer possible to authenticate to
     the telnet interface.
-    
+
     To disable this security feature (and go back to the dark Varnish 2 & 3
     days) use ``secret-file = disabled``. This is discouraged.
-    
+
     To enable the secret-file, give the path to a file on the filesystem that
     preferably has random content and is both accessible to the varnish daemon
     and a command line utility like varnishadm.
 
     An example buildout part to generate such a file could be::
-    
+
         [varnish-secret]
         recipe = plone.recipe.command
         command = dd if=/dev/random of=${buildout:directory}/var/varnish_secret count=1
@@ -406,7 +413,7 @@ Start varnish as a daemon or in foreground with the given settings. These option
     Giving secret-file the location of this file will pass on the secret to
     the varnish daemon when it starts up. Afterwards you can use varnishadm
     with the parameters -T host:port -S /path/to/varnish_secret to connect to
-    the admin telnet interface.  
+    the admin telnet interface.
 
 ``user``
     The name of the user varnish should switch to before accepting any

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -8,9 +8,13 @@ import re
 import zc.buildout
 
 DEFAULT_DOWNLOAD_URLS = {
-    '4': 'https://repo.varnish-cache.org/source/varnish-4.0.3.tar.gz',
+    '4.0': 'https://repo.varnish-cache.org/source/varnish-4.0.3.tar.gz',
+    '4.1': 'https://repo.varnish-cache.org/source/varnish-4.1.3.tar.gz',
+    '4':   'https://repo.varnish-cache.org/source/varnish-4.1.3.tar.gz',
 }
-DEFAULT_VERSION = '4'
+# Testing gives no output for 4.1, waiting for input for some reason.
+# So we stick to 4.0 as default for the moment.
+DEFAULT_VERSION = '4.0'
 
 COOKIE_WHITELIST_DEFAULT = """\
 statusmessages
@@ -268,7 +272,7 @@ class ConfigureRecipe(BaseRecipe):
         self.install()
 
     def create_varnish_configuration(self):
-        major_version = self.options['varnish_version']
+        major_version = self.options['varnish_version'][0]
         config = {}
         config['version'] = major_version
 


### PR DESCRIPTION
- 4.0: uses 4.0.3, will stick to 4.0.x
- 4.1: uses 4.1.2, will stick to 4.1.x
- 4: uses 4.1.2, will stick to 4.x.

4 is the default.