### PR TITLE
If "secret-file" is "disabled", do not output the "-S" option at all

### DIFF
--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -430,10 +430,7 @@ class ScriptRecipe(BaseRecipe):
             if self.options.get('name', None):
                 print >>tf, '    -n %s \\' % self.options['name']
             if not self.options.get('secret-file', 'nosecret') == 'nosecret':
-                if self.options['secret-file'].lower() == "disabled":
-                    # disable authentication on admin interface, dangerous
-                    print >>tf, '    -S \\'
-                else:
+                if self.options['secret-file'].lower() != "disabled":
                     # use shared secret file for admin auth
                     print >>tf, '    -S %s \\' % self.options['secret-file']
             for parameter in parameters:

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -151,11 +151,8 @@ Check the contents of the control script reflect our new options::
     >>> 'varnish' in os.listdir('bin')
     True
 
-    >>> print open(varnish_bin).read()
-    #!/bin/sh
-    ...
-        -S \
-    ...
+    >>> '-S' in open(varnish_bin).read()
+    False
 
 Check if we can specify a key file for varnishadm access::
 


### PR DESCRIPTION
Otherwise, varnishd won't start, with error: "option requires an argument -- 'S'"