### PR TITLE
Fix secret disabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0a5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix: to disable the secret-file authentication, an empty parameter should be
+  passed to varnishd on startup.
+  [fredvd, nutjob4life]    
 
 
 2.0a4 (2016-02-23)

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -430,7 +430,10 @@ class ScriptRecipe(BaseRecipe):
             if self.options.get('name', None):
                 print >>tf, '    -n %s \\' % self.options['name']
             if not self.options.get('secret-file', 'nosecret') == 'nosecret':
-                if self.options['secret-file'].lower() != "disabled":
+                if self.options['secret-file'].lower() == "disabled":
+                    # disable authentication on admin interface, dangerous
+                    print >>tf, '    -S \\'
+                else:
                     # use shared secret file for admin auth
                     print >>tf, '    -S %s \\' % self.options['secret-file']
             for parameter in parameters:

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -432,7 +432,7 @@ class ScriptRecipe(BaseRecipe):
             if not self.options.get('secret-file', 'nosecret') == 'nosecret':
                 if self.options['secret-file'].lower() == "disabled":
                     # disable authentication on admin interface, dangerous
-                    print >>tf, '    -S \\'
+                    print >>tf, '    -S "" \\'
                 else:
                     # use shared secret file for admin auth
                     print >>tf, '    -S %s \\' % self.options['secret-file']

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -151,8 +151,11 @@ Check the contents of the control script reflect our new options::
     >>> 'varnish' in os.listdir('bin')
     True
 
-    >>> '-S' in open(varnish_bin).read()
-    False
+    >>> print open(varnish_bin).read()
+    #!/bin/sh
+    ...
+        -S \
+    ...
 
 Check if we can specify a key file for varnishadm access::
 

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -154,7 +154,7 @@ Check the contents of the control script reflect our new options::
     >>> print open(varnish_bin).read()
     #!/bin/sh
     ...
-        -S \
+        -S "" \
     ...
 
 Check if we can specify a key file for varnishadm access::


### PR DESCRIPTION
Fix: to disable the secret-file authentication, an empty parameter should be passed to varnishd on startup.