### PR TITLE
Jinja template fixes

### DIFF
--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -310,7 +310,7 @@ class ConfigureRecipe(BaseRecipe):
         # inject custom vcl
         config['custom'] = {}
         for name in ('vcl_recv', 'vcl_hit', 'vcl_miss', 'vcl_fetch',
-                     'vcl_deliver', 'vcl_pipe'):
+                     'vcl_deliver', 'vcl_pipe', 'vcl_backend_response'):
             config['custom'][name] = self.options.get(name, '')
 
         config['backends'] = self._process_backends()

--- a/plone/recipe/varnish/templates/varnish4.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish4.vcl.jinja2
@@ -53,7 +53,7 @@ acl purge {
 }
 
 sub vcl_recv {
-    {{custom[vcl_recv]}}
+    {{custom['vcl_recv']}}
     {% if vhosting|length > 1 %}
     # virtual hosting matches
     {% for vh in vhosting %}
@@ -171,7 +171,7 @@ sub vcl_recv {
 }
 
 sub vcl_pipe {
-    {{custom[vcl_pipe]}}
+    {{custom['vcl_pipe']}}
     # By default Connection: close is set on all piped requests, to stop
     # connection reuse from sending future requests directly to the
     # (potentially) wrong backend. If you do want this to happen, you can undo
@@ -182,21 +182,21 @@ sub vcl_pipe {
 }
 
 sub vcl_pass {
-    {{custom[vcl_pass]}}
+    {{custom['vcl_pass']}}
     return (fetch);
 }
 
 sub vcl_hash {
-    {{custom[vcl_hash]}}
+    {{custom['vcl_hash']}}
 }
 
 sub vcl_purge {
-    {{custom[vcl_purge]}}
+    {{custom['vcl_purge']}}
     return (synth(200, "Purged"));
 }
 
 sub vcl_hit {
-    {{custom[vcl_hit]}}
+    {{custom['vcl_hit']}}
     if (obj.ttl >= 0s) {
         // A pure unadultered hit, deliver it
         # normal hit
@@ -239,7 +239,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
-    {{custom[vcl_miss]}}
+    {{custom['vcl_miss']}}
 
     if (req.method == "PURGE") {
         set req.method = "GET";
@@ -252,12 +252,12 @@ sub vcl_miss {
 }
 
 sub vcl_backend_fetch{
-    {{custom[vcl_backend_fetch]}}
+    {{custom['vcl_backend_fetch']}}
     return (fetch);
 }
 
 sub vcl_backend_response {
-    {{custom[vcl_backend_response]}}
+    {{custom['vcl_backend_response']}}
 
     # The object is not cacheable
     if (beresp.http.Set-Cookie) {
@@ -336,7 +336,7 @@ sub vcl_deliver {
     if (resp.http.Cache-Control ~ ", proxy-revalidate") {
         set resp.http.Cache-Control = regsub(resp.http.Cache-Control, ", proxy-revalidate", "");
     }
-    {{custom[vcl_deliver]}}
+    {{custom['vcl_deliver']}}
 }
 
 /*


### PR DESCRIPTION
1) It was missing vcl_backend_response from templating scope

2) fix jinja template when calling custom dictionary keys without quoting its keys. The Result was that any vcl custom injection made in buildout was ignored in template rendering.