### PR TITLE
Updated default urls to varnish security releases.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.0a6 (unreleased)
 ------------------
 
+- Updated default urls to `varnish security releases <https://varnish-cache.org/security/VSV00001.html>`_.
+  Also updated these urls to not use the ``repo.varnish-cache.org`` domain,
+  because those links will stop working at `31 August 2017 <https://varnish-cache.org/news/index.html#package-repository-status>`_.
+  [maurits]
+
 - Fix VCL director: from round-robin to round_robin, tests refactored.
   [cleberjsantos]
 

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -10,9 +10,9 @@ import zc.buildout
 
 
 DEFAULT_DOWNLOAD_URLS = {
-    '4.0': 'https://repo.varnish-cache.org/source/varnish-4.0.3.tar.gz',
-    '4.1': 'https://repo.varnish-cache.org/source/varnish-4.1.3.tar.gz',
-    '4': 'https://repo.varnish-cache.org/source/varnish-4.1.3.tar.gz',
+    '4.0': 'http://varnish-cache.org/_downloads/varnish-4.0.5.tar.gz',
+    '4.1': 'http://varnish-cache.org/_downloads/varnish-4.1.8.tar.gz',
+    '4': 'http://varnish-cache.org/_downloads/varnish-4.1.8.tar.gz',
 }
 # Testing gives no output for 4.1, waiting for input for some reason.
 # So we stick to 4.0 as default for the moment.


### PR DESCRIPTION
See https://varnish-cache.org/security/VSV00001.html.

Also updated these urls to not use the repo.varnish-cache.org domain, because those links will stop working at 31 August 2017.
See https://varnish-cache.org/news/index.html#package-repository-status.