### PR TITLE
Changed default downloads to .tgz instead of .tar.gz.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0a7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed default downloads to ``.tgz`` instead of ``.tar.gz``.
+  For some reason they were renamed after the last release of this recipe.
+  [maurits]
 
 
 2.0a6 (2017-08-15)

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -10,9 +10,9 @@ import zc.buildout
 
 
 DEFAULT_DOWNLOAD_URLS = {
-    '4.0': 'http://varnish-cache.org/_downloads/varnish-4.0.5.tar.gz',
-    '4.1': 'http://varnish-cache.org/_downloads/varnish-4.1.8.tar.gz',
-    '4': 'http://varnish-cache.org/_downloads/varnish-4.1.8.tar.gz',
+    '4.0': 'http://varnish-cache.org/_downloads/varnish-4.0.5.tgz',
+    '4.1': 'http://varnish-cache.org/_downloads/varnish-4.1.8.tgz',
+    '4': 'http://varnish-cache.org/_downloads/varnish-4.1.8.tgz',
 }
 # Testing gives no output for 4.1, waiting for input for some reason.
 # So we stick to 4.0 as default for the moment.

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -188,7 +188,7 @@ Test the varnish download with an older version::
 
     >>> varnish_4 = simplest + '''
     ... varnish_version = 4
-    ... download-url = https://repo.varnish-cache.org/source/varnish-4.0.2.tar.gz
+    ... download-url = http://varnish-cache.org/_downloads/varnish-4.0.2.tgz
     ... '''
     >>> write('buildout.cfg', varnish_4 % globals())
 


### PR DESCRIPTION
For some reason they were renamed after the last release of this recipe.