### PR TITLE
Strip query string before testing which urls to strip cookies on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0a8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Stripped query string before testing which urls to strip cookies on.
+  https://github.com/collective/plone.recipe.varnish/issues/42 [instification]
 
 
 2.0a7 (2017-08-16)

--- a/plone/recipe/varnish/templates/varnish4.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish4.vcl.jinja2
@@ -133,8 +133,9 @@ sub vcl_recv {
     /* cookies for pass */
     {% for rule in cookiepass %}
     {# this part need review #}
+    set req.http.UrlNoQs = regsub(req.url, "\?.*$", "");
     if (req.http.Cookie && req.http.Cookie ~ "{{rule['match']}}") {
-        if (req.url ~ "{{rule['exclude']}}") {
+        if (req.http.UrlNoQs ~ "{{rule['exclude']}}") {
             unset req.http.cookie;
             return(pipe);
         }


### PR DESCRIPTION
This is a PR to resolve issue #42 

Instead of comparing the url to `req.url` compare it to a new variable set on `req.http` which has the query string removed.