### PR TITLE
Don't open bin/createcoverage results in browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ script:
   - bin/code-analysis
   - bin/test
 after_success:
-  - bin/createcoverage
+  - bin/createcoverage -d .
   - python -m coverage.pickle2json
   - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0a8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix to failing travis tests, ``bin/createcoverage`` tries to open browser.
+  [instification]
 
 
 2.0a7 (2017-08-16)

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 .. image:: https://travis-ci.org/collective/plone.recipe.varnish.svg?branch=master
     :target: https://travis-ci.org/collective/plone.recipe.varnish
 
-.. image:: https://coveralls.io/repos/collective/plone.recipe.varnish/badge.svg?branch=master&service=github
+.. image:: https://coveralls.io/repos/github/collective/plone.recipe.varnish/badge.svg?branch=master
     :target: https://coveralls.io/github/collective/plone.recipe.varnish?branch=master
+
 
 Varnish recipe for buildout
 ===========================


### PR DESCRIPTION
Travis tests are hanging. I can see from running `bin/createcoverage` locally that it opens the results in the browser. By outputting to the local directory the script exits and travis continues.

I'm not sure if this is then going to affect how coverage.pickle2json and coveralls work - ie: are the results now going anywhere?