### PR TITLE
Fix 'six' problem on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.mo
 *.pyc
 *.pyo
+.Python
 .installed.cfg
 .mr.developer.cfg
 buildout.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - echo "[buildout]" > $HOME/.buildout/default.cfg
   - echo "download-cache = $HOME/buildout-cache/downloads" >> $HOME/.buildout/default.cfg
   - echo "eggs-directory = $HOME/buildout-cache/eggs" >> $HOME/.buildout/default.cfg
-  - pip install --upgrade pip setuptools zc.buildout coveralls
+  - pip install --upgrade pip setuptools zc.buildout coveralls six==1.10.0
 install:
   - sed -ie "s#plone-4.3.x.cfg#plone-$PLONE_VERSION.cfg#" travis.cfg
   - buildout -N -t 3 -c travis.cfg


### PR DESCRIPTION
`VersionConflict: (six 1.11.0 (/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages), Requirement.parse('six==1.10.0'))`

See for example https://travis-ci.org/collective/plone.recipe.varnish/jobs/311289820