### PR TITLE
Use 4.1 version by default (4.0 was default until now).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use 4.1 version by default (4.0 was default until now).  [maurits]
 
 
 2.0 (2017-12-15)

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -15,9 +15,7 @@ DEFAULT_DOWNLOAD_URLS = {
     '4.1': 'http://varnish-cache.org/_downloads/varnish-4.1.9.tgz',
     '4': 'http://varnish-cache.org/_downloads/varnish-4.1.9.tgz',
 }
-# Testing gives no output for 4.1, waiting for input for some reason.
-# So we stick to 4.0 as default for the moment.
-DEFAULT_VERSION = '4.0'
+DEFAULT_VERSION = '4.1'
 
 COOKIE_WHITELIST_DEFAULT = """\
 statusmessages

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -34,11 +34,13 @@ Let's create a minimum buildout that uses the current plone.recipe.varnish::
 
 Let's run it::
 
-    >>> print system(buildout_bin)
-    Installing varnish-build.
-    varnish-build: Downloading ...
-    varnish-build: Unpacking and configuring
-    ...
+    >>> output = system(buildout_bin)
+    >>> if 'Installing varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'varnish-build: Downloading' not in output:
+    ...     print(output)
+    >>> if 'varnish-build: Unpacking and configuring' not in output:
+    ...     print(output)
 
 A control script got created::
 
@@ -83,12 +85,15 @@ Test out customising the storage options with a new test buildout::
 
 Let's run it::
 
-    >>> print system(buildout_bin)
-    Uninstalling varnish.
-    Updating varnish-build.
-    Updating varnish-configuration.
-    Installing varnish.
-    ...
+    >>> output = system(buildout_bin)
+    >>> if 'Uninstalling varnish.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-configuration.' not in output:
+    ...     print(output)
+    >>> if 'Installing varnish.' not in output:
+    ...     print(output)
 
 Check the contents of the control script are correct::
 
@@ -112,12 +117,15 @@ well::
 
 Let's run it::
 
-    >>> print system(buildout_bin)
-    Uninstalling varnish.
-    Updating varnish-build.
-    Updating varnish-configuration.
-    Installing varnish.
-    ...
+    >>> output = system(buildout_bin)
+    >>> if 'Uninstalling varnish.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-configuration.' not in output:
+    ...     print(output)
+    >>> if 'Installing varnish.' not in output:
+    ...     print(output)
 
 Check the contents of the control script reflect our new options::
 
@@ -139,12 +147,15 @@ Check if we can disable the pre shared key secret file for varnishadm access::
 
 Let's run it::
 
-    >>> print system(buildout_bin)
-    Uninstalling varnish.
-    Updating varnish-build.
-    Updating varnish-configuration.
-    Installing varnish.
-    ...
+    >>> output = system(buildout_bin)
+    >>> if 'Uninstalling varnish.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-configuration.' not in output:
+    ...     print(output)
+    >>> if 'Installing varnish.' not in output:
+    ...     print(output)
 
 Check the contents of the control script reflect our new options::
 
@@ -166,12 +177,15 @@ Check if we can specify a key file for varnishadm access::
 
 Let's run it::
 
-    >>> print system(buildout_bin)
-    Uninstalling varnish.
-    Updating varnish-build.
-    Updating varnish-configuration.
-    Installing varnish.
-    ...
+    >>> output = system(buildout_bin)
+    >>> if 'Uninstalling varnish.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-configuration.' not in output:
+    ...     print(output)
+    >>> if 'Installing varnish.' not in output:
+    ...     print(output)
 
 Check the contents of the control script reflect our new options::
 
@@ -194,9 +208,12 @@ Test the varnish download with an older version::
 
 Let's run it::
 
-    >>> print system(buildout_bin)
-    Uninstalling varnish.
-    Updating varnish-build.
-    Updating varnish-configuration.
-    Installing varnish.
-    ...
+    >>> output = system(buildout_bin)
+    >>> if 'Uninstalling varnish.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-configuration.' not in output:
+    ...     print(output)
+    >>> if 'Installing varnish.' not in output:
+    ...     print(output)

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -62,13 +62,7 @@ Check the contents of the control script are correct::
 Check the config is syntactically correct by compiling it to C::
 
     >>> print system(varnish_bin + ' -C')
-    /* ---===### include/vcl.h ###===--- */
-    <BLANKLINE>
-    /*
-     * NB:  This file is machine generated, DO NOT EDIT!
-     *
-     * Edit and run generate.py instead
-     */
+    /* ---===### include/vdef.h ###===--- */
     <BLANKLINE>
     ...
     const struct VCL_conf VCL_conf = {

--- a/plone/recipe/varnish/tests/test_recipe.py
+++ b/plone/recipe/varnish/tests/test_recipe.py
@@ -5,10 +5,9 @@ from zc.buildout.testing import buildoutTearDown
 from zc.buildout.testing import install
 from zc.buildout.testing import install_develop
 
+import commands
 import doctest
 import shutil
-import subprocess
-import sys
 import unittest
 
 
@@ -16,33 +15,10 @@ FLAGS = \
     doctest.ELLIPSIS | \
     doctest.NORMALIZE_WHITESPACE | \
     doctest.REPORT_ONLY_FIRST_FAILURE
-
-# FIXME - check for other platforms
-MUST_CLOSE_FDS = not sys.platform.startswith('win')
-
-
-def exec_system(command, input='', with_exit_code=False):
-    p = subprocess.Popen(
-        command,
-        shell=True,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=MUST_CLOSE_FDS
-    )
-    i, o, e = (p.stdin, p.stdout, p.stderr)
-    if input:
-        i.write(input.encode('utf8'))
-    i.close()
-    result = o.read() + e.read()
-    o.close()
-    e.close()
-    output = result.decode('utf-8')
-    if with_exit_code:
-        # Use the with_exit_code=True parameter when you want to test the exit
-        # code of the command you're running.
-        output += 'EXIT CODE: %s' % p.wait()
-    return output
+# We used to have a custom exec_system from zc.buildout,
+# but that one fails to give output back with varnish 4.1.
+# So we fall back to a simpler version.
+exec_system = commands.getoutput
 
 
 def setUp(test):


### PR DESCRIPTION
We used 4.0 until now, because while running the tests with 4.1 Travis kept waiting for input.
Let's see if that got magically fixed.
If it works now, we may have more hope of getting varnish 5 working too.