### PR TITLE
fix grace-sick default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix grace-sick default.
+  [mamico]
 
 2.2.0 (2018-01-05)
 ------------------

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -306,7 +306,7 @@ class ConfigureRecipe(BaseRecipe):
         #         'When using saint-mode verbose headers must be off'
         #     )
         config['gracehealthy'] = self.options.get('grace-healthy', None)
-        config['gracesick'] = self.options.get('grace-sick', 600)
+        config['gracesick'] = self.options.get('grace-sick', '600s')
 
         # fixup cookies for better plone caching
         config['cookiewhitelist'] = [


### PR DESCRIPTION
Without this change I'have this error (varnish 4.1):

```
Error:
Message from VCC-compiler:
Expected ID got ';'
(program line 166), at
('.../parts/varnish-config/varnish.vcl' Line 265 Pos 27)
    set beresp.grace = 600;
--------------------------#

Running VCC-compiler failed, exited with 2
VCL compilation failed
```