### PR TITLE
Pick up vcl_hash custom code insertion again from the buildout recipe values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Pick up vcl_hash custom code insertion again from the buildout recipe values.
+  It was defined in the varnish templates but never picked up.
+  [fredvd]
+
 - Initial Varnish 6 support.
   [cleberjsantos]
 

--- a/README.rst
+++ b/README.rst
@@ -249,7 +249,7 @@ These options are available for the recipe part plone.recipe.varnish:configurati
     Specifies hostnames or IP addresses for purge ACL. By default ``localhost`` and
     the backends are allowed to purge. Additional allowed hosts are listed here.
 
-``vcl_recv``, ``vcl_hit``, ``vcl_miss``, ``vcl_backend_fetch``, ``vcl_backend_response``, ``vcl_deliver``, ``vcl_pipe``, ``vlc_purge``
+``vcl_recv``, ``vcl_hit``, ``vcl_miss``, ``vcl_backend_fetch``, ``vcl_backend_response``, ``vcl_deliver``, ``vcl_pipe``, ``vlc_purge``, ``vcl_hash``
     Insert arbitrary VCL code into the generated config.
 
 ``verbose-headers``

--- a/base.cfg
+++ b/base.cfg
@@ -16,6 +16,7 @@ ignore-develop = true
 recipe = plone.recipe.codeanalysis
 directory = ${buildout:directory}/plone/recipe/varnish
 flake8-exclude = bootstrap.py,bootstrap-buildout.py,docs,*.egg.,omelette
+flake8-ignore = B901,D001,E501,P001,T000,T001,S001,I003,W504,W605
 flake8-max-complexity = 15
 flake8-extensions =
     flake8-blind-except

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -329,7 +329,7 @@ class ConfigureRecipe(BaseRecipe):
         config['custom'] = {}
         for name in ('vcl_recv', 'vcl_hit', 'vcl_miss',
                      'vcl_backend_fetch', 'vcl_purge', 'vcl_deliver',
-                     'vcl_pipe', 'vcl_backend_response','vcl_hash'):
+                     'vcl_pipe', 'vcl_backend_response', 'vcl_hash'):
             config['custom'][name] = self.options.get(name, '')
 
         config['backends'] = self._process_backends()

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -329,7 +329,7 @@ class ConfigureRecipe(BaseRecipe):
         config['custom'] = {}
         for name in ('vcl_recv', 'vcl_hit', 'vcl_miss',
                      'vcl_backend_fetch', 'vcl_purge', 'vcl_deliver',
-                     'vcl_pipe', 'vcl_backend_response'):
+                     'vcl_pipe', 'vcl_backend_response','vcl_hash'):
             config['custom'][name] = self.options.get(name, '')
 
         config['backends'] = self._process_backends()

--- a/travis.cfg
+++ b/travis.cfg
@@ -7,7 +7,6 @@ parts +=
 recipe = plone.recipe.codeanalysis[recommended]
 clean-lines = True
 debug-statements = True
-flake8-ignore = B901,D001,E501,P001,T000,T001,S001,I003
 flake8-max-complexity = 12
 multiprocessing = True
 pre-commit-hook = True


### PR DESCRIPTION
It was defined in the varnish vcl templates but never picked up.