### PR TITLE
Updated default varnish 4 version to latest 4.1.11.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Updated default varnish 4 version to latest 4.1.11.  [maurits]
+
 - Pick up vcl_hash custom code insertion again from the buildout recipe values.
   It was defined in the varnish templates but never picked up.
   [fredvd]

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -12,8 +12,8 @@ import zc.buildout
 
 DEFAULT_DOWNLOAD_URLS = {
     '4.0': 'http://varnish-cache.org/_downloads/varnish-4.0.5.tgz',
-    '4.1': 'http://varnish-cache.org/_downloads/varnish-4.1.9.tgz',
-    '4': 'http://varnish-cache.org/_downloads/varnish-4.1.9.tgz',
+    '4.1': 'http://varnish-cache.org/_downloads/varnish-4.1.11.tgz',
+    '4': 'http://varnish-cache.org/_downloads/varnish-4.1.11.tgz',
     '5.0': 'http://varnish-cache.org/_downloads/varnish-5.0.0.tgz',
     '5.1': 'http://varnish-cache.org/_downloads/varnish-5.1.3.tgz',
     '5.2': 'http://varnish-cache.org/_downloads/varnish-5.2.1.tgz',


### PR DESCRIPTION
I see this actually partially overlaps with PR #67 but that one is a bit older so it updates to 4.1.10 instead. That PR should be revisited afterwards, as it had a Travis failure.