### PR TITLE
Simplified test buildout setup by not using plone versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ cache:
 python:
   - 2.7
 env:
-  - PLONE_VERSION=4.3.x
-  - PLONE_VERSION=5.0.x
+  - LATEST=false
+  - LATEST=true
 matrix:
   allow_failures:
-    - env: PLONE_VERSION=5.0.x
+    - env: LATEST=true
 addons:
   apt:
     packages:
@@ -28,7 +28,7 @@ before_install:
   - echo "eggs-directory = $HOME/buildout-cache/eggs" >> $HOME/.buildout/default.cfg
   - pip install --upgrade pip setuptools zc.buildout coveralls six==1.10.0
 install:
-  - sed -ie "s#plone-4.3.x.cfg#plone-$PLONE_VERSION.cfg#" travis.cfg
+  - if test "$LATEST" == "true"; then sed -ie "/versions.cfg/d" travis.cfg; fi
   - buildout -N -t 3 -c travis.cfg
 script:
   - bin/code-analysis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Simplified test buildout setup by not using plone versions.
+  See `issue #69 <https://github.com/collective/plone.recipe.varnish/issues/69>`_.  [maurits]
+
 - Updated default varnish 4 version to latest 4.1.11.  [maurits]
 
 - Pick up vcl_hash custom code insertion again from the buildout recipe values.

--- a/base.cfg
+++ b/base.cfg
@@ -15,7 +15,7 @@ ignore-develop = true
 [code-analysis]
 recipe = plone.recipe.codeanalysis
 directory = ${buildout:directory}/plone/recipe/varnish
-flake8-exclude = bootstrap.py,bootstrap-buildout.py,docs,*.egg.,omelette
+flake8-exclude = docs,*.egg.,omelette
 flake8-ignore = B901,D001,E501,P001,T000,T001,S001,I003,W504,W605
 flake8-max-complexity = 15
 flake8-extensions =

--- a/bootstrap-4.3.x.sh
+++ b/bootstrap-4.3.x.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# see https://community.plone.org/t/not-using-bootstrap-py-as-default/620
-rm -r ./lib ./include ./local ./bin
-ln -fs plone-4.3.x.cfg buildout.cfg
-virtualenv --clear .
-./bin/pip install --upgrade pip setuptools zc.buildout
-./bin/buildout 

--- a/bootstrap-5.0.x.sh
+++ b/bootstrap-5.0.x.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# see https://community.plone.org/t/not-using-bootstrap-py-as-default/620
-ln -fs plone-5.0.x.cfg buildout.cfg
-rm -r ./lib ./include ./local ./bin
-virtualenv --clear .
-./bin/pip install --upgrade pip setuptools zc.buildout
-./bin/buildout

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+rm -r ./lib ./include ./local ./bin
+virtualenv -p python2.7 --clear .
+./bin/pip install --upgrade pip setuptools zc.buildout
+./bin/buildout

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    base.cfg
-    http://dist.plone.org/release/4.3.10/versions.cfg
-    versions.cfg

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    base.cfg
-    http://dist.plone.org/release/5.0.5/versions.cfg
-    versions.cfg

--- a/travis.cfg
+++ b/travis.cfg
@@ -1,5 +1,7 @@
 [buildout]
-extends = plone-4.3.x.cfg
+extends =
+    base.cfg
+    versions.cfg
 parts +=
     createcoverage
 
@@ -9,7 +11,7 @@ clean-lines = True
 debug-statements = True
 flake8-max-complexity = 12
 multiprocessing = True
-pre-commit-hook = True
+pre-commit-hook = False
 prefer-single-quotes = True
 return-status-codes = True
 


### PR DESCRIPTION
See issue #69.

- `buildout.cfg` now extends `base.cfg` and `versions.cfg`.
- `travis.cfg` by default extends both but has a slightly different code-analysis setup. The different setup may not make sense anymore, but that is how it was until now. code-analysis passes with both setups.
- In `.travis.yml` we do one run with standard `travis.cfg`, and one allowed failure with `travis.cfg` minus the `versions.cfg`. We could skip that and have just one job.

So if we don't mind further simplification/unification then there is some room, and I can do that. But we can also merge as is, when Travis passes.