### PR TITLE
Update Varnish versions. Small fixes in versioning & tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 python:
   - 2.7
 env:
-  - LATEST=false
   - LATEST=true
 matrix:
   allow_failures:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,15 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable building sphinx documentation in the varnish-build/cmmi stage of installing the software. 
+  [fredvd]
+  
+- Update Varnish versions. Anything below 6.0.X is officially unmaintained. Update versions 6 and 6.0 to latest version 6.0.4
+  [fredvd]
+
+- Set default version to version 6, downloading 6.0.4 if no url is provided.
+  [fredvd]
+
 
 
 2.3.0 (2019-03-26)

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -18,9 +18,12 @@ DEFAULT_DOWNLOAD_URLS = {
     '5.1': 'http://varnish-cache.org/_downloads/varnish-5.1.3.tgz',
     '5.2': 'http://varnish-cache.org/_downloads/varnish-5.2.1.tgz',
     '5': 'http://varnish-cache.org/_downloads/varnish-5.2.1.tgz',
-    '6': 'http://varnish-cache.org/_downloads/varnish-6.0.0.tgz',
+    '6': 'http://varnish-cache.org/_downloads/varnish-6.0.4.tgz',
+    '6.0': 'http://varnish-cache.org/_downloads/varnish-6.0.4.tgz',
+    '6.2': 'http://varnish-cache.org/_downloads/varnish-6.2.1.tgz',
+
 }
-DEFAULT_VERSION = '5'
+DEFAULT_VERSION = '6'
 DEFAULT_VCL_VERSION = '4.0'
 
 COOKIE_WHITELIST_DEFAULT = """\
@@ -110,11 +113,13 @@ class BuildRecipe(CMMIRecipe, BaseRecipe):
         This is overidden in order to enable parallel jobs in make.
         """
         options = self.configure_options
+
         if options is None:
             options = '--prefix="%s"' % dest
         if self.extra_options:
             options += ' %s' % self.extra_options
-
+        print ("options: " + options)
+        options += ' --with-sphinx-build=false'
         # C
         system('%s %s' % (self.configure_cmd, options))
 

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -204,10 +204,10 @@ Check the contents of the control script reflect our new options::
         -S .../sample-buildout/var/varnish-secret \
     ...
 
-Check if Varnish version's 5.2.x::
+Check if Varnish default version's is 6.0.x::
 
     >>> output = system(varnishd + ' -V')
-    >>> if 'varnishd (varnish-5.2.' not in output:
+    >>> if 'varnishd (varnish-6.0.' not in output:
     ...     print(output)
 
 
@@ -220,8 +220,8 @@ Test the varnish download with an older version::
     ...
     ... [varnish-build]
     ... recipe = plone.recipe.varnish:build
-    ... varnish_version = 4.0
-    ... url = http://varnish-cache.org/_downloads/varnish-4.0.5.tgz
+    ... varnish_version = 4.1
+    ... url = http://varnish-cache.org/_downloads/varnish-4.1.11.tgz
     ... jobs = 4
     ...
     ... [varnish-configuration]
@@ -249,52 +249,8 @@ Let's run it::
     >>> if 'Installing varnish.' not in output.replace('\n',''):
     ...     print(output)
 
-Check if Varnish version's old 4.0.5::
+Check if Varnish version's old 4.1.11::
 
     >>> output = system(varnishd + ' -V')
-    >>> if 'varnishd (varnish-4.0.5 revision' not in output:
-    ...     print(output)
-
-Test with Varnish 5::
-
-    >>> varnish_5 = '''
-    ... [buildout]
-    ... parts = varnish-build varnish-configuration varnish
-    ... find-links = %(sample_buildout)s/eggs
-    ...
-    ... [varnish-build]
-    ... recipe = plone.recipe.varnish:build
-    ... varnish_version = 5.1
-    ... jobs = 4
-    ...
-    ... [varnish-configuration]
-    ... recipe = plone.recipe.varnish:configuration
-    ... daemon = ${varnish-build:location}/sbin/varnishd
-    ... backends = 127.0.0.1:8081
-    ...
-    ... [varnish]
-    ... recipe = plone.recipe.varnish:script
-    ... bind = 127.0.0.1:8001'''
-    >>> write('buildout.cfg', varnish_5 % globals())
-
-Let's run it::
-
-    >>> output = system(buildout_bin)
-    >>> if 'Traceback' in output:
-    ...     print(output)
-    >>> if 'Uninstalling varnish.' not in output:
-    ...     print(output)
-    >>> if 'Uninstalling varnish-configuration.' not in output:
-    ...     print(output)
-    >>> if 'Uninstalling varnish-build.' not in output:
-    ...     print(output)
-    >>> if 'Installing varnish-configuration.' not in output:
-    ...     print(output)
-    >>> if 'Installing varnish.' not in output:
-    ...     print(output)
-
-Check if Varnish version's 5.1.x::
-
-    >>> output = system(varnishd + ' -V')
-    >>> if 'varnishd (varnish-5.1.' not in output:
+    >>> if 'varnishd (varnish-4.1.11 revision' not in output:
     ...     print(output)


### PR DESCRIPTION
Update versions 6 and 6.0 to latest version 6.0.4 Anything below 6.0.X is officially unmaintained from varnish-cache.org
Set default version to version 6, downloading 6.0.4 if no url is provided.
Fix double env assignment in travis.yml
Disable building sphinx documentation in the varnish-build/cmmi stage of installing the software.
