### PR TITLE
run the purge when entering the vcl_hit state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,12 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Disable building sphinx documentation in the varnish-build/cmmi stage of installing the software. 
+- Run the purge when entering the vcl_hit state
+  [erral]
+
+- Disable building sphinx documentation in the varnish-build/cmmi stage of installing the software.
   [fredvd]
-  
+
 - Update Varnish versions. Anything below 6.0.X is officially unmaintained. Update versions 6 and 6.0 to latest version 6.0.4
   [fredvd]
 

--- a/plone/recipe/varnish/templates/varnish4.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish4.vcl.jinja2
@@ -198,6 +198,14 @@ sub vcl_purge {
 
 sub vcl_hit {
     {{custom['vcl_hit']}}
+
+    if (req.method == "PURGE") {
+        set req.method = "GET";
+        set req.http.X-purger = "Purged";
+        return(synth(200, "Purged. in hit " + req.url));
+    }
+
+
     if (obj.ttl >= 0s) {
         // A pure unadultered hit, deliver it
         # normal hit
@@ -228,12 +236,6 @@ sub vcl_hit {
         }
     }
     {% endif %}
-
-    if (req.method == "PURGE") {
-        set req.method = "GET";
-        set req.http.X-purger = "Purged";
-        return(synth(200, "Purged. in hit " + req.url));
-    }
 
     // fetch & deliver once we get the result
     return (fetch);

--- a/plone/recipe/varnish/templates/varnish5.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish5.vcl.jinja2
@@ -205,6 +205,17 @@ sub vcl_purge {
 
 sub vcl_hit {
     {{custom['vcl_hit']}}
+
+    if (req.method == "PURGE") {
+        set req.method = "GET";
+        {% if minor_version > 1 %}
+        call custom_purge;
+        {% else %}
+        set req.http.X-purger = "Purged";
+        return(synth(200, "Purged. in hit " + req.url));
+        {% endif %}
+    }
+
     if (obj.ttl >= 0s) {
         // A pure unadultered hit, deliver it
         # normal hit
@@ -235,16 +246,6 @@ sub vcl_hit {
         }
     }
     {% endif %}
-
-    if (req.method == "PURGE") {
-        set req.method = "GET";
-        {% if minor_version > 1 %}
-        call custom_purge;
-        {% else %}
-        set req.http.X-purger = "Purged";
-        return(synth(200, "Purged. in hit " + req.url));
-        {% endif %}
-    }
 
     // fetch & deliver once we get the result
     return (miss); # Dead code, keep as a safeguard
@@ -399,4 +400,3 @@ sub custom_purge {
     }
 }
 {% endif %}
-

--- a/plone/recipe/varnish/templates/varnish6.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish6.vcl.jinja2
@@ -209,6 +209,17 @@ sub vcl_purge {
 
 sub vcl_hit {
     {{custom['vcl_hit']}}
+
+    if (req.method == "PURGE") {
+        set req.method = "GET";
+        {% if minor_version > 1 %}
+        call custom_purge;
+        {% else %}
+        set req.http.X-purger = "Purged";
+        return(synth(200, "Purged. in hit " + req.url));
+        {% endif %}
+    }
+
     if (obj.ttl >= 0s) {
         // A pure unadultered hit, deliver it
         # normal hit
@@ -239,16 +250,6 @@ sub vcl_hit {
         }
     }
     {% endif %}
-
-    if (req.method == "PURGE") {
-        set req.method = "GET";
-        {% if minor_version > 1 %}
-        call custom_purge;
-        {% else %}
-        set req.http.X-purger = "Purged";
-        return(synth(200, "Purged. in hit " + req.url));
-        {% endif %}
-    }
 
     // fetch & deliver once we get the result
     return (miss); # Dead code, keep as a safeguard
@@ -403,4 +404,3 @@ sub custom_purge {
     }
 }
 {% endif %}
-


### PR DESCRIPTION
When debugging some varnish issues in a client's website, we have found that our varnish (configured with the defaults provided by the recipe) **never** purged its contents when requested to do so.

After some trials and errors we found that changing the order of the `PURGE` method checking in vcl_hit fixes most of the issues.

According to our debugging session with varnishlog, a `PURGE` request is _in esence_ a `GET` request with a special `PURGE` marker, but it's treated like a `GET`. So Varnish enters the `vcl_hit` method and the first thing it checks is if the object is in the cache (`obj.ttl > 0`) and if so returns it.

Replacing the order of the `PURGE` check we purge the object and guarantee that the next access will be a `MISS` which we think is the intended feature even before of checking if the object is in the cache.

This PR will be followed by a couple of PRs in plone.app.caching and plone.cachepurging regarding the `PURGE` requests missing the `Host` header to let Varnish know what should it purge.

@aitzol @libargutxi