### PR TITLE
Add an option to modify the health-check url defaulting to Plone's /ok view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,12 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Disable building sphinx documentation in the varnish-build/cmmi stage of installing the software. 
+- Add an option to modify the health-check url defaulting to Plone's /ok view.
+  [erral]
+
+- Disable building sphinx documentation in the varnish-build/cmmi stage of installing the software.
   [fredvd]
-  
+
 - Update Varnish versions. Anything below 6.0.X is officially unmaintained. Update versions 6 and 6.0 to latest version 6.0.4
   [fredvd]
 

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -313,6 +313,7 @@ class ConfigureRecipe(BaseRecipe):
         #     )
         config['gracehealthy'] = self.options.get('grace-healthy', None)
         config['gracesick'] = self.options.get('grace-sick', '600s')
+        config['healthprobeurl'] = self.options.get('health-probe-url', '/ok')
 
         # fixup cookies for better plone caching
         config['cookiewhitelist'] = [

--- a/plone/recipe/varnish/templates/varnish4.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish4.vcl.jinja2
@@ -19,7 +19,7 @@ backend {{backend['name']}} {
    .between_bytes_timeout  = {{backend['between_bytes_timeout']}};
    {% if gracehealthy %}
    .probe = {
-        .url = "/";
+        .url = "{{healthprobeurl}}";
         .timeout = 5s;
         .interval = 15s;
         .window = 10;

--- a/plone/recipe/varnish/templates/varnish5.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish5.vcl.jinja2
@@ -22,7 +22,7 @@ backend {{backend['name']}} {
    .between_bytes_timeout  = {{backend['between_bytes_timeout']}};
    {% if gracehealthy %}
    .probe = {
-        .url = "/";
+        .url = "{{healthprobeurl}}";
         .timeout = 5s;
         .interval = 15s;
         .window = 10;
@@ -399,4 +399,3 @@ sub custom_purge {
     }
 }
 {% endif %}
-

--- a/plone/recipe/varnish/templates/varnish6.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish6.vcl.jinja2
@@ -26,7 +26,7 @@ backend {{backend['name']}} {
    .between_bytes_timeout  = {{backend['between_bytes_timeout']}};
    {% if gracehealthy %}
    .probe = {
-        .url = "/";
+        .url = "{{healthprobeurl}}";
         .timeout = 5s;
         .interval = 15s;
         .window = 10;
@@ -403,4 +403,3 @@ sub custom_purge {
     }
 }
 {% endif %}
-

--- a/plone/recipe/varnish/vclgen.py
+++ b/plone/recipe/varnish/vclgen.py
@@ -154,6 +154,7 @@ class VclGenerator(object):
         data['code404page'] = self.cfg['code404page']
         data['gracehealthy'] = self.cfg['gracehealthy']
         data['gracesick'] = self.cfg['gracesick']
+        data['healthprobeurl'] = self.cfg['healthprobeurl']
         # render vcl file
         template = TEMPLATES_BY_MAJORVERSION[data['version'][0]]
         return template.render(**data)


### PR DESCRIPTION
When using the load-balancing feature of Varnish, the configuration created with this recipe configures Varnish to request the front-page of the Plone site.

With this change a new option is added to the recipe to let the user configure the URL he wants and defaulting it to [Plone's `/ok` view](https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/browser/okay.py).

@libargutxi @aitzol