### PR TITLE
bugfix: omitting healthprobeurl resulted in "None"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 6.0.0b3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- BUGFIX: omitting health-probe-url resulted in `.url = "None";` [frisi]
 
 
 6.0.0b2 (2020-07-14)

--- a/plone/recipe/varnish/vclgen.py
+++ b/plone/recipe/varnish/vclgen.py
@@ -135,12 +135,12 @@ class VclGenerator(object):
         data['code404page'] = self.cfg['code404page']
         data['gracehealthy'] = self.cfg['gracehealthy']
         data['gracesick'] = self.cfg['gracesick']
-        data['healthprobeurl'] = self.cfg.get('healthprobeurl', '/ok')
-        data['healthprobetimeout'] = self.cfg.get('healthprobetimeout', '5s')
-        data['healthprobeinterval'] = self.cfg.get('healthprobeinterval', '15s')
-        data['healthprobewindow'] = self.cfg.get('healthprobewindow', '10')
-        data['healthprobethreshold'] = self.cfg.get('healthprobethreshold', '8')
-        data['healthprobeinitial'] = self.cfg.get('healthprobeinitial', None)
+        data['healthprobeurl'] = self.cfg.get('healthprobeurl') or '/ok'
+        data['healthprobetimeout'] = self.cfg.get('healthprobetimeout') or '5s'
+        data['healthprobeinterval'] = self.cfg.get('healthprobeinterval') or '15s'
+        data['healthprobewindow'] = self.cfg.get('healthprobewindow') or '10'
+        data['healthprobethreshold'] = self.cfg.get('healthprobethreshold') or '8'
+        data['healthprobeinitial'] = self.cfg.get('healthprobeinitial') or None
 
         data['vcl_version'] = 4.0
         # render vcl file


### PR DESCRIPTION
just noticed that i introduced a regression when moving the defaults from `recipe` to `vlcgen` - sorry about that @fredvd...
a bugfix release would be welcome as users not providing a probeurl and using grace-health will always have sick backends and varnish not responding to any requests.