### PR TITLE
secret filename case sensitive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 6.0.10.1 (unreleased)
 ---------------------
 
+- BUGFIX: secret filename case sensitive [mamico]
+
 - Remove strange check to make vhm_map generation work again. Fixes https://github.com/collective/plone.recipe.varnish/issues/19
   [agitator]
 

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -397,7 +397,7 @@ class ScriptRecipe(BaseRecipe):
         data['cache_size'] = self.options['cache-size']
         data['mode'] = self.options.get('mode', 'daemon')
         data['name'] = self.options.get('name')
-        data['secret'] = self.options.get('secret-file', 'nosecret').lower()
+        data['secret'] = self.options.get('secret-file', 'nosecret')
         data['telnet'] = self.options.get('telnet')
         data['parameters'] = self.options['runtime-parameters'].strip().split()
 

--- a/plone/recipe/varnish/templates/start_script.jinja2
+++ b/plone/recipe/varnish/templates/start_script.jinja2
@@ -24,9 +24,9 @@ exec {{daemon}} \
 {% if name %}
     -n {{name}} \
 {% endif %}
-{% if secret == 'disabled' %}
+{% if secret.lower() == 'disabled' %}
     -S "" \
-{% elif secret != 'nosecret' %}
+{% elif secret.lower() != 'nosecret' %}
     -S {{secret}} \
 {% endif %}
 {% for parameter in parameters %}

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -180,7 +180,7 @@ Check the contents of the control script reflect our new options::
 Check if we can specify a key file for varnishadm access::
 
     >>> enable_secret = simplest + '''
-    ... secret-file = ${buildout:directory}/var/varnish-secret
+    ... secret-file = ${buildout:directory}/var/varnish-Secret
     ... '''
     >>> write('buildout.cfg', enable_secret % globals())
 
@@ -206,7 +206,7 @@ Check the contents of the control script reflect our new options::
     >>> print(open(varnish_bin).read())
     #!/bin/sh
     ...
-        -S .../sample-buildout/var/varnish-secret \
+        -S .../sample-buildout/var/varnish-Secret \
     ...
 
 Check if Varnish default version is 6.0.x::


### PR DESCRIPTION
I don’t know why, but the secret file path is modified to lowercase in the recipe. This is a problem, for example,  if there are capitals in the buildout path.