### PR TITLE
allow to use the other storages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 6.0.10.1 (unreleased)
 ---------------------
 
+- Allow to configure the other storages than file and malloc (https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html)
+  [mamico]
+
 - Remove strange check to make vhm_map generation work again. Fixes https://github.com/collective/plone.recipe.varnish/issues/19
   [agitator]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 6.0.10.1 (unreleased)
 ---------------------
 
-- Allow to configure the other storages than file and malloc (https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html)
+- Allow to configure storages other than file and malloc (https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html)
   [mamico]
 
 - Remove strange check to make vhm_map generation work again. Fixes https://github.com/collective/plone.recipe.varnish/issues/19

--- a/plone/recipe/varnish/templates/start_script.jinja2
+++ b/plone/recipe/varnish/templates/start_script.jinja2
@@ -17,7 +17,7 @@ exec {{daemon}} \
 {% if telnet %}
     -T {{telnet}} \
 {% endif %}
-    -s {{cache_type}},{% if cache_type != 'malloc' %}"{{cache_location}}",{% endif %}{{cache_size}} \
+    -s {{cache_type}},{% if cache_type == 'file' %}"{{cache_location}}",{% endif %}{{cache_size}} \
 {% if mode == 'foreground' %}
     -F \
 {% endif %}

--- a/plone/recipe/varnish/tests/recipe.rst
+++ b/plone/recipe/varnish/tests/recipe.rst
@@ -145,6 +145,40 @@ Check the contents of the control script reflect our new options::
         -s malloc,2.71G \
     ...
 
+Customising our storage options again to check we can work with umem as
+well::
+
+    >>> mem_storage = simplest + '''
+    ... cache-type = umem
+    ... cache-size = 1.71G
+    ... '''
+    >>> write('buildout.cfg', mem_storage % globals())
+
+Let's run it::
+
+    >>> output = system(buildout_bin)
+    >>> if 'Traceback' in output:
+    ...     print(output)
+    >>> if 'Uninstalling varnish.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-build.' not in output:
+    ...     print(output)
+    >>> if 'Updating varnish-configuration.' not in output:
+    ...     print(output)
+    >>> if 'Installing varnish.' not in output:
+    ...     print(output)
+
+Check the contents of the control script reflect our new options::
+
+    >>> 'varnish' in os.listdir('bin')
+    True
+
+    >>> print(open(varnish_bin).read())
+    #!/bin/sh
+    ...
+        -s umem,1.71G \
+    ...
+
 Check if we can disable the pre shared key secret file for varnishadm access::
 
     >>> disable_secret = simplest + '''


### PR DESCRIPTION
Allow to configure storages other than file and malloc (i.e. umem and default)

BTW, probably nowadays the best default storage would be `default` instead of `file`.

https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
