### PR TITLE
Use Varnish 6.0.11 LTS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,10 @@
 Changelog
 =========
 
-6.0.10.1 (unreleased)
----------------------
+6.0.11 (unreleased)
+-------------------
+
+- Use Varnish 6.0.11 LTS.  [maurits]
 
 - Allow to configure storages other than file and malloc (https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html)
   [mamico]

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 rm -r ./lib ./include ./local ./bin
-virtualenv -p python2.7 --clear .
+virtualenv -p python2.7 .
 ./bin/pip install --upgrade -r requirements.txt
 ./bin/buildout

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -9,9 +9,9 @@ import re
 import zc.buildout
 
 
-DOWNLOAD_URL = "https://varnish-cache.org/_downloads/varnish-6.0.10.tgz"
+DOWNLOAD_URL = "https://varnish-cache.org/_downloads/varnish-6.0.11.tgz"
 VMODS_DOWNLOAD_URL = "https://github.com/varnish/varnish-modules/archive/0.15.1.tar.gz"
-SUPPORTED_VERSION = "6.0.10"
+SUPPORTED_VERSION = "6.0.11"
 
 COOKIE_WHITELIST_DEFAULT = """\
 statusmessages

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class PyTest(TestCommand):
 
 # versioning scheme: major/minor (positions 1-2) matches: supported varnish 6.0 LTS.
 # position 3: plone.recipe.varnish patch release X.
-version = '6.0.10.1.dev0'
+version = '6.0.11.dev0'
 
 setup(
     name='plone.recipe.varnish',


### PR DESCRIPTION
Afterwards, we should do a release.  Some bug fixes have been done.

This package can use some more love, probably starting with issue #90.  But that can wait until after a release.