### PR TITLE
Add `cookie-pass-not-exclude` config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 6.0.13 (unreleased)
 -------------------
 
+- Add `cookie-pass-not-exclude` config [mamico]
+
 - Use Varnish 6.0.13 LTS [mamico]
 
 - Add vcl_synth options to insert arbitrary vcl. [mamico]

--- a/README.rst
+++ b/README.rst
@@ -285,6 +285,11 @@ These options are available for the recipe part plone.recipe.varnish:configurati
     When an authenticated user requests a js/css/kss file,
     Plone will see you as anonymous because no cookies reach Plone.
 
+``cookie-pass-notexclude``
+    If url matches this regexp, ``cookie-pass`` exclude rules are skipped. This is useful
+    for url like ``++resource++zmi`` that requires authentication also for resources
+    like js, css, ...
+
 ``cookie-whitelist``
     When the ``cookie-pass`` is processed and does not match, this means you are
     anonymous, at least with the default ``cookie-pass`` settings.

--- a/README.rst
+++ b/README.rst
@@ -285,7 +285,7 @@ These options are available for the recipe part plone.recipe.varnish:configurati
     When an authenticated user requests a js/css/kss file,
     Plone will see you as anonymous because no cookies reach Plone.
 
-``cookie-pass-notexclude``
+``cookie-pass-not-exclude``
     If url matches this regexp, ``cookie-pass`` exclude rules are skipped. This is useful
     for url like ``++resource++zmi`` that requires authentication also for resources
     like js, css, ...

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -30,7 +30,7 @@ COOKIE_PASS_DEFAULT = """\
 "auth_token|__ac(|_(name|password|persistent))=":"\.(js|css|kss)$"
 """  # noqa: W605
 COOKIE_PASS_RE = re.compile('"(.*)":"(.*)"')
-
+COOKIE_PASS_NOT_EXCLUDE_DEFAULT = "/\+\+resources\+\+zmi/"
 
 class BaseRecipe(object):
     def __init__(self, buildout, name, options):
@@ -155,6 +155,7 @@ class ConfigureRecipe(BaseRecipe):
         self.options.setdefault("between-bytes-timeout", "60s")
         self.options.setdefault("purge-hosts", "")
         self.options.setdefault("cookie-pass", COOKIE_PASS_DEFAULT)
+        self.options.setdefault("cookie-pass-not-exclude", COOKIE_PASS_NOT_EXCLUDE_DEFAULT)
         self.options.setdefault("cookie-whitelist", COOKIE_WHITELIST_DEFAULT)
         # Set default vcl_hash function so it doesn't use the default.vcl hostname
         self.options.setdefault("vcl_hash", DEFAULT_VCL_HASH)
@@ -287,6 +288,7 @@ class ConfigureRecipe(BaseRecipe):
             if not mg and len(mg) != 2:
                 continue
             config["cookiepass"].append(dict(zip(("match", "exclude"), mg)))
+        config["cookiepassnotexclude"] = self.options["cookie-pass-not-exclude"]
         # inject custom vcl
         config["custom"] = {}
         for name in (

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -32,6 +32,7 @@ COOKIE_PASS_DEFAULT = """\
 COOKIE_PASS_RE = re.compile('"(.*)":"(.*)"')
 COOKIE_PASS_NOT_EXCLUDE_DEFAULT = "/\+\+resources\+\+zmi/"
 
+
 class BaseRecipe(object):
     def __init__(self, buildout, name, options):
         self.name = name
@@ -155,7 +156,9 @@ class ConfigureRecipe(BaseRecipe):
         self.options.setdefault("between-bytes-timeout", "60s")
         self.options.setdefault("purge-hosts", "")
         self.options.setdefault("cookie-pass", COOKIE_PASS_DEFAULT)
-        self.options.setdefault("cookie-pass-not-exclude", COOKIE_PASS_NOT_EXCLUDE_DEFAULT)
+        self.options.setdefault(
+            "cookie-pass-not-exclude", COOKIE_PASS_NOT_EXCLUDE_DEFAULT
+        )
         self.options.setdefault("cookie-whitelist", COOKIE_WHITELIST_DEFAULT)
         # Set default vcl_hash function so it doesn't use the default.vcl hostname
         self.options.setdefault("vcl_hash", DEFAULT_VCL_HASH)

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -30,7 +30,7 @@ COOKIE_PASS_DEFAULT = """\
 "auth_token|__ac(|_(name|password|persistent))=":"\.(js|css|kss)$"
 """  # noqa: W605
 COOKIE_PASS_RE = re.compile('"(.*)":"(.*)"')
-COOKIE_PASS_NOT_EXCLUDE_DEFAULT = "/\+\+resources\+\+zmi/"
+COOKIE_PASS_NOT_EXCLUDE_DEFAULT = "/\+\+resource\+\+zmi/"
 
 
 class BaseRecipe(object):

--- a/plone/recipe/varnish/recipe.py
+++ b/plone/recipe/varnish/recipe.py
@@ -30,7 +30,7 @@ COOKIE_PASS_DEFAULT = """\
 "auth_token|__ac(|_(name|password|persistent))=":"\.(js|css|kss)$"
 """  # noqa: W605
 COOKIE_PASS_RE = re.compile('"(.*)":"(.*)"')
-COOKIE_PASS_NOT_EXCLUDE_DEFAULT = "/\+\+resource\+\+zmi/"
+COOKIE_PASS_NOT_EXCLUDE_DEFAULT = "/\\+\\+resource\\+\\+zmi/"
 
 
 class BaseRecipe(object):

--- a/plone/recipe/varnish/templates/varnish6.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish6.vcl.jinja2
@@ -147,7 +147,7 @@ sub vcl_recv {
     {# this part need review #}
     set req.http.UrlNoQs = regsub(req.url, "\?.*$", "");
     if (req.http.Cookie && req.http.Cookie ~ "{{rule['match']}}") {
-        if (req.url !~ "{{cookiepasssnotexclude}}" && req.http.UrlNoQs ~ "{{rule['exclude']}}") {
+        if (req.url !~ "{{cookiepassnotexclude}}" && req.http.UrlNoQs ~ "{{rule['exclude']}}") {
             unset req.http.cookie;
             return(pipe);
         }

--- a/plone/recipe/varnish/templates/varnish6.vcl.jinja2
+++ b/plone/recipe/varnish/templates/varnish6.vcl.jinja2
@@ -147,7 +147,7 @@ sub vcl_recv {
     {# this part need review #}
     set req.http.UrlNoQs = regsub(req.url, "\?.*$", "");
     if (req.http.Cookie && req.http.Cookie ~ "{{rule['match']}}") {
-        if (req.http.UrlNoQs ~ "{{rule['exclude']}}") {
+        if (req.url !~ "{{cookiepasssnotexclude}}" && req.http.UrlNoQs ~ "{{rule['exclude']}}") {
             unset req.http.cookie;
             return(pipe);
         }

--- a/plone/recipe/varnish/tests/vclgen.rst
+++ b/plone/recipe/varnish/tests/vclgen.rst
@@ -72,6 +72,7 @@ Basic check::
     ...         {'match': '__ac(|_(name|password|persistent))=',
     ...          'exclude': '\.(js|css|kss)' }
     ...     ],
+    ...     'cookiepassnotexclude': '/\\+\\+resource\\+\\+zmi/',
     ...     'gracehealthy': '10s',
     ...     'gracesick': '1h',
     ...     'code404page' : True,
@@ -274,6 +275,7 @@ When gracehealthy is set, probes for the backend are activated::
     ...         {'match': '__ac(|_(name|password|persistent))=',
     ...          'exclude': '\.(js|css|kss)' }
     ...     ],
+    ...     'cookiepassnotexclude': '/\\+\\+resource\\+\\+zmi/',
     ...     'gracehealthy': '10s',
     ...     'gracesick': '1h',
     ...     'code404page' : True,

--- a/plone/recipe/varnish/vclgen.py
+++ b/plone/recipe/varnish/vclgen.py
@@ -120,6 +120,7 @@ class VclGenerator(object):
         data["custom"] = self.cfg["custom"]
         data["cookiewhitelist"] = self.cfg["cookiewhitelist"]
         data["cookiepass"] = self.cfg["cookiepass"]
+        data["cookiepassnotexclude"] = self.cfg["cookiepassnotexclude"]
         data["code404page"] = self.cfg["code404page"]
         data["gracehealthy"] = self.cfg["gracehealthy"]
         data["gracesick"] = self.cfg["gracesick"]


### PR DESCRIPTION
``cookie-pass-not-exclude``
    If url matches this regexp, ``cookie-pass`` exclude rules are skipped. This is useful
    for url like ``++resource++zmi`` that requires authentication also for resources
    like js, css, ...
